### PR TITLE
Separate build script for git4mps from the review plugin

### DIFF
--- a/.mps/modules.xml
+++ b/.mps/modules.xml
@@ -4,6 +4,7 @@
     <projectModules>
       <modulePath path="$PROJECT_DIR$/languages/com.workday.mps.review.lang/com.workday.mps.review.lang.mpl" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/com.workday.mps.flux/com.workday.mps.flux.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/com.workday.mps.git4mps/com.workday.mps.git4mps.msd" folder="build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.workday.mps.review.build.meta/com.workday.mps.review.build.meta.msd" folder="build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.workday.mps.review.build/com.workday.mps.review.build.msd" folder="build" />
       <modulePath path="$PROJECT_DIR$/solutions/com.workday.mps.review.git/com.workday.review.git.msd" folder="" />

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ task buildPluginIncremental(group: 'MPS Build',
                  dependsOn: generateBuildScripts) {
   doLast {
     println 'Building code reviewer plugin ===================================='
+    runAnt "${rootDir}/dist/git4mpsPlugin.xml", 'build'
     runAnt "${rootDir}/dist/reviewPlugin.xml", 'build'
     println 'Code reviewer plugin has been successfully built ================='
     println()
@@ -128,12 +129,39 @@ task buildPlugin(group: 'MPS Build',
                  dependsOn: generateBuildScripts) {
   doLast {
     println 'Building code reviewer plugin ===================================='
+    runAnt "${rootDir}/dist/git4mpsPlugin.xml", 'clean', 'generate', 'build'
     runAnt "${rootDir}/dist/reviewPlugin.xml", 'clean', 'generate', 'build'
     println 'Code reviewer plugin has been successfully built ================='
     println()
   }
 }
 
+task zipGit4mpsPlugin(group: 'MPS Build',
+               type: Zip,
+               description: 'Archive git4mps plugin into zip file') {
+  destinationDir = file("${rootDir}/dist/build/artifacts/")
+  archiveName = 'git4mps.zip'
+  
+  from "${rootDir}/dist/build/artifacts/git4mpsPlugin/git4mps"
+}
+
+task zipCodeReviewerPlugin(group: 'MPS Build',
+               type: Zip,
+               description: 'Archive code reviewer plugin into zip file') {
+  destinationDir = file("${rootDir}/dist/build/artifacts/")
+  archiveName = 'com.workday.mps.review.zip'
+  
+  from "${rootDir}/dist/build/artifacts/reviewPlugin/com.workday.mps.review"
+}
+
+task zipPlugin(group: 'MPS Build',
+               description: 'Archive plugins into zip files',
+               dependsOn: [buildPlugin, zipGit4mpsPlugin, zipCodeReviewerPlugin]) {
+  doLast {
+    println 'Plugins have been successfully zipped ================='
+    println()
+  }
+}
 
 
 defaultTasks 'build'

--- a/build.gradle
+++ b/build.gradle
@@ -136,27 +136,36 @@ task buildPlugin(group: 'MPS Build',
   }
 }
 
+task zipGit4mpsBuildPlugin(group: 'MPS Build',
+               type: Zip,
+               description: 'Archive git4mps build plugin into zip file') {
+  from "${rootDir}/dist/build/artifacts/git4mpsPlugin/"
+  include "com.workday.mps.git4mps.build/**"
+  destinationDir = file("${rootDir}/dist/build/artifacts/")
+  archiveName = 'com.workday.mps.git4mps.build.zip'
+}
+
 task zipGit4mpsPlugin(group: 'MPS Build',
                type: Zip,
                description: 'Archive git4mps plugin into zip file') {
+  from "${rootDir}/dist/build/artifacts/git4mpsPlugin/"
+  include "com.workday.mps.git4mps/**"
   destinationDir = file("${rootDir}/dist/build/artifacts/")
-  archiveName = 'git4mps.zip'
-  
-  from "${rootDir}/dist/build/artifacts/git4mpsPlugin/git4mps"
+  archiveName = 'com.workday.mps.git4mps.zip'
 }
 
 task zipCodeReviewerPlugin(group: 'MPS Build',
                type: Zip,
                description: 'Archive code reviewer plugin into zip file') {
+  from "${rootDir}/dist/build/artifacts/reviewPlugin/"
+  include "com.workday.mps.review/**"
   destinationDir = file("${rootDir}/dist/build/artifacts/")
   archiveName = 'com.workday.mps.review.zip'
-  
-  from "${rootDir}/dist/build/artifacts/reviewPlugin/com.workday.mps.review"
 }
 
 task zipPlugin(group: 'MPS Build',
                description: 'Archive plugins into zip files',
-               dependsOn: [buildPlugin, zipGit4mpsPlugin, zipCodeReviewerPlugin]) {
+               dependsOn: [buildPlugin, zipGit4mpsBuildPlugin, zipGit4mpsPlugin, zipCodeReviewerPlugin]) {
   doLast {
     println 'Plugins have been successfully zipped ================='
     println()

--- a/buildScripts/reviewPluginBuildScripts.xml
+++ b/buildScripts/reviewPluginBuildScripts.xml
@@ -35,6 +35,35 @@
   
   <target name="assemble" depends="classes, declare-mps-tasks">
     <mkdir dir="${build.layout}" />
+    <mkdir dir="${build.tmp}/default/com.workday.mps.git4mps.jar" />
+    <mkdir dir="${build.tmp}/default/com.workday.mps.git4mps.jar/META-INF" />
+    <echoxml file="${build.tmp}/default/com.workday.mps.git4mps.jar/META-INF/module.xml">
+      <module namespace="com.workday.mps.git4mps" type="solution" uuid="35a83c38-8969-4574-b716-a7b3acd78eec">
+        <dependencies />
+        <classpath>
+          <entry path="." />
+        </classpath>
+        <sources jar="com.workday.mps.git4mps-src.jar" descriptor="com.workday.mps.git4mps.msd" />
+      </module>
+    </echoxml>
+    <jar destfile="${build.layout}/com.workday.mps.git4mps.jar" duplicate="preserve">
+      <fileset dir="${build.tmp}/java/out/com.workday.mps.git4mps" />
+      <fileset dir="${project.home}/solutions/com.workday.mps.git4mps/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
+      <fileset dir="${build.tmp}/default/com.workday.mps.git4mps.jar" />
+    </jar>
+    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-com.workday.mps.git4mps-models">
+      <fileset dir="${project.home}/solutions/com.workday.mps.git4mps/models" includes="**/*.mps, **/*.metadata, **/*.history, **/*.mpsr, **/.model" />
+    </copyModels>
+    <jar destfile="${build.layout}/com.workday.mps.git4mps-src.jar" duplicate="preserve">
+      <fileset dir="${project.home}/solutions/com.workday.mps.git4mps/source_gen">
+        <exclude name="**/trace.info" />
+        <exclude name="**/exports" />
+        <exclude name="**/checkpoints" />
+        <exclude name="**/*.mps" />
+      </fileset>
+      <zipfileset file="${project.home}/solutions/com.workday.mps.git4mps/com.workday.mps.git4mps.msd" prefix="module" />
+      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-com.workday.mps.git4mps-models" prefix="module/models" />
+    </jar>
     <mkdir dir="${build.tmp}/default/com.workday.mps.review.build.jar" />
     <mkdir dir="${build.tmp}/default/com.workday.mps.review.build.jar/META-INF" />
     <echoxml file="${build.tmp}/default/com.workday.mps.review.build.jar/META-INF/module.xml">
@@ -78,7 +107,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.com.workday.mps.review.build" />
+  <target name="compileJava" depends="java.compile.com.workday.mps.git4mps, java.compile.com.workday.mps.review.build" />
   
   <target name="processResources" />
   
@@ -159,6 +188,7 @@
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.workflow.preset.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.ide.build.jar" />
       <chunk>
+        <module file="${project.home}/solutions/com.workday.mps.git4mps/com.workday.mps.git4mps.msd" />
         <module file="${project.home}/solutions/com.workday.mps.review.build/com.workday.mps.review.build.msd" />
       </chunk>
       <jvmargs>
@@ -177,7 +207,21 @@
   
   <target name="makeDependents" />
   
-  <target name="java.compile.com.workday.mps.review.build">
+  <target name="java.compile.com.workday.mps.git4mps">
+    <mkdir dir="${project.home}/solutions/com.workday.mps.git4mps/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/com.workday.mps.git4mps" />
+    <javac destdir="${build.tmp}/java/out/com.workday.mps.git4mps" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${project.home}/solutions/com.workday.mps.git4mps/source_gen" />
+      </src>
+      <classpath>
+        <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
+      </classpath>
+    </javac>
+  </target>
+  
+  <target name="java.compile.com.workday.mps.review.build" depends="java.compile.com.workday.mps.git4mps">
     <mkdir dir="${project.home}/solutions/com.workday.mps.review.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/com.workday.mps.review.build" />
     <javac destdir="${build.tmp}/java/out/com.workday.mps.review.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
@@ -186,12 +230,14 @@
         <path location="${project.home}/solutions/com.workday.mps.review.build/source_gen" />
       </src>
       <classpath>
+        <pathelement path="${build.tmp}/java/out/com.workday.mps.git4mps" />
         <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
       </classpath>
     </javac>
   </target>
   
   <target name="cleanSources">
+    <delete dir="${project.home}/solutions/com.workday.mps.git4mps/source_gen" />
     <delete dir="${project.home}/solutions/com.workday.mps.review.build/source_gen" />
   </target>
 </project>

--- a/solutions/com.workday.mps.git4mps/com.workday.mps.git4mps.msd
+++ b/solutions/com.workday.mps.git4mps/com.workday.mps.git4mps.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="com.workday.mps.review.build" uuid="aa79ef09-da8f-4761-af89-e6223d0e9718" moduleVersion="0" compileInMPS="true">
+<solution name="com.workday.mps.git4mps" uuid="35a83c38-8969-4574-b716-a7b3acd78eec" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -9,7 +9,6 @@
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
     <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
-    <dependency reexport="false">35a83c38-8969-4574-b716-a7b3acd78eec(com.workday.mps.git4mps)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -19,7 +18,6 @@
   <dependencyVersions>
     <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
     <module reference="35a83c38-8969-4574-b716-a7b3acd78eec(com.workday.mps.git4mps)" version="0" />
-    <module reference="aa79ef09-da8f-4761-af89-e6223d0e9718(com.workday.mps.review.build)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
   </dependencyVersions>
 </solution>

--- a/solutions/com.workday.mps.git4mps/models/build.mps
+++ b/solutions/com.workday.mps.git4mps/models/build.mps
@@ -205,7 +205,7 @@
         <node concept="398223" id="7mrE8nX9Ool" role="39821P">
           <node concept="3_J27D" id="7mrE8nX9Oon" role="Nbhlr">
             <node concept="3Mxwew" id="7mrE8nX9Opj" role="3MwsjC">
-              <property role="3MwjfP" value="libs" />
+              <property role="3MwjfP" value="lib" />
             </node>
           </node>
           <node concept="3ygNvl" id="7mrE8nX9Oqw" role="39821P">
@@ -295,9 +295,6 @@
       <node concept="2iUeEo" id="3wrDZJThql9" role="2iVFfd">
         <property role="2iUeEt" value="Workday" />
         <property role="2iUeEu" value="https://www.workday.com/" />
-      </node>
-      <node concept="m$_yC" id="7Oiry496RCC" role="m$_yJ">
-        <ref role="m$_y1" node="4GMBmWUHpN2" resolve="Git4Idea" />
       </node>
       <node concept="m$_yC" id="7Oiry496REE" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />

--- a/solutions/com.workday.mps.git4mps/models/build.mps
+++ b/solutions/com.workday.mps.git4mps/models/build.mps
@@ -201,7 +201,7 @@
     </node>
     <node concept="1l3spV" id="3wrDZJThql0" role="1l3spN">
       <node concept="m$_wl" id="7mrE8nX2hr0" role="39821P">
-        <ref role="m_rDy" node="3wrDZJThqkR" resolve="git4mps" />
+        <ref role="m_rDy" node="3wrDZJThqkR" resolve="com.workday.mps.git4mps" />
         <node concept="398223" id="7mrE8nX9Ool" role="39821P">
           <node concept="3_J27D" id="7mrE8nX9Oon" role="Nbhlr">
             <node concept="3Mxwew" id="7mrE8nX9Opj" role="3MwsjC">
@@ -262,9 +262,12 @@
           </node>
         </node>
       </node>
+      <node concept="m$_wl" id="7Oiry496RLE" role="39821P">
+        <ref role="m_rDy" node="7Oiry496Rtp" resolve="com.workday.mps.git4mps.build" />
+      </node>
     </node>
     <node concept="m$_wf" id="3wrDZJThqkR" role="3989C9">
-      <property role="m$_wk" value="git4mps" />
+      <property role="m$_wk" value="com.workday.mps.git4mps" />
       <node concept="3_J27D" id="3wrDZJThqkS" role="m$_yQ">
         <node concept="3Mxwew" id="3wrDZJThqkT" role="3MwsjC">
           <property role="3MwjfP" value="Git Integration - MPS Stubs" />
@@ -272,22 +275,16 @@
       </node>
       <node concept="3_J27D" id="3wrDZJThqkU" role="m$_w8">
         <node concept="3Mxwew" id="3wrDZJThqkV" role="3MwsjC">
-          <property role="3MwjfP" value="1.0" />
+          <property role="3MwjfP" value="1.0.0" />
         </node>
       </node>
       <node concept="m$_yB" id="7SqVNqmc0Ql" role="m$_yh">
         <property role="1ZOk41" value="true" />
         <ref role="m$_yA" node="3wrDZJThqp9" resolve="git4mps" />
       </node>
-      <node concept="m$_yB" id="3wrDZJThsby" role="m$_yh">
-        <ref role="m$_yA" node="3wrDZJThs02" resolve="com.workday.mps.git4mps" />
-      </node>
-      <node concept="m$_yC" id="3wrDZJThsgm" role="m$_yJ">
-        <ref role="m$_y1" to="al5i:33r_JpZ6k_l" resolve="com.mbeddr.platform.build" />
-      </node>
       <node concept="3_J27D" id="3wrDZJThqkY" role="m_cZH">
         <node concept="3Mxwew" id="3wrDZJThqkZ" role="3MwsjC">
-          <property role="3MwjfP" value="git4mps" />
+          <property role="3MwjfP" value="com.workday.mps.git4mps" />
         </node>
       </node>
       <node concept="3_J27D" id="3wrDZJThql5" role="3s6cr7">
@@ -296,6 +293,40 @@
         </node>
       </node>
       <node concept="2iUeEo" id="3wrDZJThql9" role="2iVFfd">
+        <property role="2iUeEt" value="Workday" />
+        <property role="2iUeEu" value="https://www.workday.com/" />
+      </node>
+      <node concept="m$_yC" id="7Oiry496RCC" role="m$_yJ">
+        <ref role="m$_y1" node="4GMBmWUHpN2" resolve="Git4Idea" />
+      </node>
+      <node concept="m$_yC" id="7Oiry496REE" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
+      </node>
+    </node>
+    <node concept="m$_wf" id="7Oiry496Rtp" role="3989C9">
+      <property role="m$_wk" value="com.workday.mps.git4mps.build" />
+      <node concept="3_J27D" id="7Oiry496Rtr" role="m$_yQ">
+        <node concept="3Mxwew" id="7Oiry496RyJ" role="3MwsjC">
+          <property role="3MwjfP" value="com.workday.mps.git4mps.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="7Oiry496Rtt" role="m_cZH">
+        <node concept="3Mxwew" id="7Oiry496RyL" role="3MwsjC">
+          <property role="3MwjfP" value="com.workday.mps.git4mps.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="7Oiry496Rtv" role="m$_w8">
+        <node concept="3Mxwew" id="7Oiry496Rzr" role="3MwsjC">
+          <property role="3MwjfP" value="1.0.0" />
+        </node>
+      </node>
+      <node concept="m$_yB" id="7Oiry496R$5" role="m$_yh">
+        <ref role="m$_yA" node="3wrDZJThs02" resolve="com.workday.mps.git4mps" />
+      </node>
+      <node concept="m$_yC" id="7Oiry496R$J" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:33r_JpZ6k_l" resolve="com.mbeddr.platform.build" />
+      </node>
+      <node concept="2iUeEo" id="7Oiry496RFm" role="2iVFfd">
         <property role="2iUeEt" value="Workday" />
         <property role="2iUeEu" value="https://www.workday.com/" />
       </node>

--- a/solutions/com.workday.mps.git4mps/models/build.mps
+++ b/solutions/com.workday.mps.git4mps/models/build.mps
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ce9396f7-a2dc-46eb-9df9-af482f8fe831(com.workday.mps.git4mps.build)">
+  <persistence version="9" />
+  <languages>
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
+  </languages>
+  <imports>
+    <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+    <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
+  </imports>
+  <registry>
+    <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
+      <concept id="5481553824944787378" name="jetbrains.mps.build.structure.BuildSourceProjectRelativePath" flags="ng" index="55IIr" />
+      <concept id="9126048691955220717" name="jetbrains.mps.build.structure.BuildLayout_File" flags="ng" index="28jJK3">
+        <child id="9126048691955220762" name="path" index="28jJRO" />
+      </concept>
+      <concept id="7321017245476976379" name="jetbrains.mps.build.structure.BuildRelativePath" flags="ng" index="iG8Mu">
+        <child id="7321017245477039051" name="compositePart" index="iGT6I" />
+      </concept>
+      <concept id="4993211115183325728" name="jetbrains.mps.build.structure.BuildProjectDependency" flags="ng" index="2sgV4H">
+        <reference id="5617550519002745380" name="script" index="1l3spb" />
+        <child id="4129895186893471026" name="artifacts" index="2JcizS" />
+      </concept>
+      <concept id="927724900262033858" name="jetbrains.mps.build.structure.BuildSource_JavaOptions" flags="ng" index="2_Ic$z">
+        <property id="927724900262033861" name="generateDebugInfo" index="2_Ic$$" />
+      </concept>
+      <concept id="4380385936562003279" name="jetbrains.mps.build.structure.BuildString" flags="ng" index="NbPM2">
+        <child id="4903714810883783243" name="parts" index="3MwsjC" />
+      </concept>
+      <concept id="8618885170173601777" name="jetbrains.mps.build.structure.BuildCompositePath" flags="nn" index="2Ry0Ak">
+        <property id="8618885170173601779" name="head" index="2Ry0Am" />
+        <child id="8618885170173601778" name="tail" index="2Ry0An" />
+      </concept>
+      <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
+      <concept id="7389400916848050060" name="jetbrains.mps.build.structure.BuildLayout_NamedContainer" flags="ng" index="3981dR">
+        <child id="4380385936562148502" name="containerName" index="Nbhlr" />
+      </concept>
+      <concept id="7389400916848036984" name="jetbrains.mps.build.structure.BuildLayout_Folder" flags="ng" index="398223" />
+      <concept id="7389400916848136194" name="jetbrains.mps.build.structure.BuildFolderMacro" flags="ng" index="398rNT">
+        <child id="7389400916848144618" name="defaultPath" index="398pKh" />
+      </concept>
+      <concept id="7389400916848153117" name="jetbrains.mps.build.structure.BuildSourceMacroRelativePath" flags="ng" index="398BVA">
+        <reference id="7389400916848153130" name="macro" index="398BVh" />
+      </concept>
+      <concept id="5617550519002745364" name="jetbrains.mps.build.structure.BuildLayout" flags="ng" index="1l3spV" />
+      <concept id="5617550519002745363" name="jetbrains.mps.build.structure.BuildProject" flags="ng" index="1l3spW">
+        <property id="4915877860348071612" name="fileName" index="turDy" />
+        <property id="5204048710541015587" name="internalBaseDirectory" index="2DA0ip" />
+        <child id="4796668409958418110" name="scriptsDir" index="auvoZ" />
+        <child id="6647099934206700656" name="plugins" index="10PD9s" />
+        <child id="7389400916848080626" name="parts" index="3989C9" />
+        <child id="5617550519002745381" name="dependencies" index="1l3spa" />
+        <child id="5617550519002745378" name="macros" index="1l3spd" />
+        <child id="5617550519002745372" name="layout" index="1l3spN" />
+      </concept>
+      <concept id="8654221991637384182" name="jetbrains.mps.build.structure.BuildFileIncludesSelector" flags="ng" index="3qWCbU">
+        <property id="8654221991637384184" name="pattern" index="3qWCbO" />
+      </concept>
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
+        <child id="7389400916848037006" name="children" index="39821P" />
+      </concept>
+      <concept id="5610619299013057363" name="jetbrains.mps.build.structure.BuildLayout_ImportContent" flags="ng" index="3ygNvl">
+        <reference id="5610619299013057365" name="target" index="3ygNvj" />
+        <child id="6789562173791401562" name="selectors" index="1juEy9" />
+      </concept>
+      <concept id="5610619299014309452" name="jetbrains.mps.build.structure.BuildSource_JavaExternalJarRef" flags="ng" index="3yrxFa">
+        <reference id="5610619299014309453" name="jar" index="3yrxFb" />
+      </concept>
+      <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
+      <concept id="4903714810883702019" name="jetbrains.mps.build.structure.BuildTextStringPart" flags="ng" index="3Mxwew">
+        <property id="4903714810883755350" name="text" index="3MwjfP" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
+      <concept id="7832771629084799699" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginVendor" flags="ng" index="2iUeEo">
+        <property id="7832771629084799702" name="name" index="2iUeEt" />
+        <property id="7832771629084799701" name="url" index="2iUeEu" />
+      </concept>
+      <concept id="6592112598314498932" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPlugin" flags="ng" index="m$_wf">
+        <property id="6592112598314498927" name="id" index="m$_wk" />
+        <child id="7832771629084912518" name="vendor" index="2iVFfd" />
+        <child id="6592112598314498931" name="version" index="m$_w8" />
+        <child id="6592112598314499050" name="content" index="m$_yh" />
+        <child id="6592112598314499028" name="dependencies" index="m$_yJ" />
+        <child id="6592112598314499021" name="name" index="m$_yQ" />
+        <child id="6592112598314855574" name="containerName" index="m_cZH" />
+        <child id="2172791612906637490" name="description" index="3s6cr7" />
+      </concept>
+      <concept id="6592112598314498926" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_Plugin" flags="ng" index="m$_wl">
+        <reference id="6592112598314801433" name="plugin" index="m_rDy" />
+      </concept>
+      <concept id="6592112598314499036" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginModule" flags="ng" index="m$_yB">
+        <property id="4034578608468849375" name="customPackaging" index="1ZOk41" />
+        <reference id="6592112598314499037" name="target" index="m$_yA" />
+      </concept>
+      <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
+        <reference id="6592112598314499066" name="target" index="m$_y1" />
+      </concept>
+      <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
+        <reference id="1265949165890536425" name="module" index="L2wRA" />
+        <child id="4356762679305730677" name="jarLocations" index="3yL2VB" />
+      </concept>
+      <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
+      <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
+        <property id="1500819558096356884" name="doNotCompile" index="2GAjPV" />
+        <child id="5253498789149547704" name="dependencies" index="3bR37C" />
+      </concept>
+      <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
+        <property id="5253498789149547713" name="reexport" index="3bR36h" />
+        <reference id="5253498789149547705" name="module" index="3bR37D" />
+      </concept>
+      <concept id="4356762679305675652" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleXml_CustomJarLocation" flags="ng" index="3yLZsm">
+        <property id="4356762679305675654" name="packagedLocation" index="3yLZsk" />
+        <child id="4356762679305675653" name="path" index="3yLZsn" />
+      </concept>
+      <concept id="4278635856200826393" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyJar" flags="ng" index="1BurEX">
+        <child id="2798275735916344703" name="customLocation" index="2gdwQb" />
+        <child id="4278635856200826394" name="path" index="1BurEY" />
+      </concept>
+      <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA" />
+      <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
+        <property id="8369506495128725901" name="compact" index="BnDLt" />
+        <property id="322010710375892619" name="uuid" index="3LESm3" />
+        <child id="322010710375956261" name="path" index="3LF7KH" />
+      </concept>
+      <concept id="7259033139236285166" name="jetbrains.mps.build.mps.structure.BuildMps_ExtractedModuleDependency" flags="nn" index="1SiIV0">
+        <child id="7259033139236285167" name="dependency" index="1SiIV1" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1l3spW" id="3wrDZJThqks">
+    <property role="TrG5h" value="git4mpsPlugin" />
+    <property role="2DA0ip" value="../../dist" />
+    <property role="turDy" value="git4mpsPlugin.xml" />
+    <node concept="2_Ic$z" id="3wrDZJThqn3" role="3989C9">
+      <property role="2_Ic$$" value="true" />
+    </node>
+    <node concept="10PD9b" id="3wrDZJThqkt" role="10PD9s" />
+    <node concept="3b7kt6" id="3wrDZJThqku" role="10PD9s" />
+    <node concept="398rNT" id="24ZpFMHU9ep" role="1l3spd">
+      <property role="TrG5h" value="project.home" />
+      <node concept="55IIr" id="24ZpFMHU9eq" role="398pKh">
+        <node concept="2Ry0Ak" id="24ZpFMHU9er" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="24ZpFMHU2ix" role="1l3spd">
+      <property role="TrG5h" value="artifacts.root" />
+      <node concept="398BVA" id="24ZpFMHU2kM" role="398pKh">
+        <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
+        <node concept="2Ry0Ak" id="24ZpFMHU2oo" role="iGT6I">
+          <property role="2Ry0Am" value="artifacts" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="24ZpFMHU9es" role="1l3spd">
+      <property role="TrG5h" value="mps_home" />
+      <node concept="398BVA" id="24ZpFMHU9et" role="398pKh">
+        <ref role="398BVh" node="24ZpFMHU2ix" resolve="artifacts.root" />
+        <node concept="2Ry0Ak" id="24ZpFMHU9eu" role="iGT6I">
+          <property role="2Ry0Am" value="MPS" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="24ZpFMHU2s7" role="1l3spd">
+      <property role="TrG5h" value="com.mbeddr.platform.artifacts" />
+      <node concept="398BVA" id="24ZpFMHU2s8" role="398pKh">
+        <ref role="398BVh" node="24ZpFMHU2ix" resolve="artifacts.root" />
+        <node concept="2Ry0Ak" id="24ZpFMHU2z_" role="iGT6I">
+          <property role="2Ry0Am" value="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+    <node concept="2sgV4H" id="4hhvq7oWSQZ" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="4hhvq7oWSR0" role="2JcizS">
+        <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="3PM$dUayXCy" role="1l3spa">
+      <ref role="1l3spb" node="4GMBmWUHnV9" resolve="IDEA_gitplugin_stubs" />
+      <node concept="398BVA" id="7mrE8nX2hmb" role="2JcizS">
+        <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+        <node concept="2Ry0Ak" id="7mrE8nX2hmR" role="iGT6I">
+          <property role="2Ry0Am" value="plugins" />
+        </node>
+      </node>
+    </node>
+    <node concept="2sgV4H" id="24ZpFMHU7SY" role="1l3spa">
+      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
+      <node concept="398BVA" id="24ZpFMHU7TK" role="2JcizS">
+        <ref role="398BVh" node="24ZpFMHU2s7" resolve="com.mbeddr.platform.artifacts" />
+      </node>
+    </node>
+    <node concept="1l3spV" id="3wrDZJThql0" role="1l3spN">
+      <node concept="m$_wl" id="7mrE8nX2hr0" role="39821P">
+        <ref role="m_rDy" node="3wrDZJThqkR" resolve="git4mps" />
+        <node concept="398223" id="7mrE8nX9Ool" role="39821P">
+          <node concept="3_J27D" id="7mrE8nX9Oon" role="Nbhlr">
+            <node concept="3Mxwew" id="7mrE8nX9Opj" role="3MwsjC">
+              <property role="3MwjfP" value="libs" />
+            </node>
+          </node>
+          <node concept="3ygNvl" id="7mrE8nX9Oqw" role="39821P">
+            <ref role="3ygNvj" node="5ded7SEwNA6" resolve="lib" />
+            <node concept="3qWCbU" id="7mrE8nX9Osj" role="1juEy9">
+              <property role="3qWCbO" value="*" />
+            </node>
+          </node>
+        </node>
+        <node concept="398223" id="7mrE8nX2hr1" role="39821P">
+          <node concept="3_J27D" id="7mrE8nX2hr2" role="Nbhlr">
+            <node concept="3Mxwew" id="7mrE8nX2hr3" role="3MwsjC">
+              <property role="3MwjfP" value="languages" />
+            </node>
+          </node>
+          <node concept="L2wRC" id="7mrE8nX2hr4" role="39821P">
+            <ref role="L2wRA" node="3wrDZJThqp9" resolve="git4mps" />
+            <node concept="3yLZsm" id="7mrE8nX2hr5" role="3yL2VB">
+              <property role="3yLZsk" value="/plugins/git4idea/lib/git4idea-rt.jar" />
+              <node concept="398BVA" id="7mrE8nX2hr6" role="3yLZsn">
+                <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+                <node concept="2Ry0Ak" id="7mrE8nX2hr7" role="iGT6I">
+                  <property role="2Ry0Am" value="plugins" />
+                  <node concept="2Ry0Ak" id="7mrE8nX2hr8" role="2Ry0An">
+                    <property role="2Ry0Am" value="git4idea" />
+                    <node concept="2Ry0Ak" id="7mrE8nX2hr9" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="7mrE8nX2hra" role="2Ry0An">
+                        <property role="2Ry0Am" value="git4idea-rt.jar" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3yLZsm" id="7mrE8nX2hrb" role="3yL2VB">
+              <property role="3yLZsk" value="/plugins/git4idea/lib/git4idea.jar" />
+              <node concept="398BVA" id="7mrE8nX2hrc" role="3yLZsn">
+                <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+                <node concept="2Ry0Ak" id="7mrE8nX2hrd" role="iGT6I">
+                  <property role="2Ry0Am" value="plugins" />
+                  <node concept="2Ry0Ak" id="7mrE8nX2hre" role="2Ry0An">
+                    <property role="2Ry0Am" value="git4idea" />
+                    <node concept="2Ry0Ak" id="7mrE8nX2hrf" role="2Ry0An">
+                      <property role="2Ry0Am" value="lib" />
+                      <node concept="2Ry0Ak" id="7mrE8nX2hrg" role="2Ry0An">
+                        <property role="2Ry0Am" value="git4idea.jar" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="m$_wf" id="3wrDZJThqkR" role="3989C9">
+      <property role="m$_wk" value="git4mps" />
+      <node concept="3_J27D" id="3wrDZJThqkS" role="m$_yQ">
+        <node concept="3Mxwew" id="3wrDZJThqkT" role="3MwsjC">
+          <property role="3MwjfP" value="Git Integration - MPS Stubs" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3wrDZJThqkU" role="m$_w8">
+        <node concept="3Mxwew" id="3wrDZJThqkV" role="3MwsjC">
+          <property role="3MwjfP" value="1.0" />
+        </node>
+      </node>
+      <node concept="m$_yB" id="7SqVNqmc0Ql" role="m$_yh">
+        <property role="1ZOk41" value="true" />
+        <ref role="m$_yA" node="3wrDZJThqp9" resolve="git4mps" />
+      </node>
+      <node concept="m$_yB" id="3wrDZJThsby" role="m$_yh">
+        <ref role="m$_yA" node="3wrDZJThs02" resolve="com.workday.mps.git4mps" />
+      </node>
+      <node concept="m$_yC" id="3wrDZJThsgm" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:33r_JpZ6k_l" resolve="com.mbeddr.platform.build" />
+      </node>
+      <node concept="3_J27D" id="3wrDZJThqkY" role="m_cZH">
+        <node concept="3Mxwew" id="3wrDZJThqkZ" role="3MwsjC">
+          <property role="3MwjfP" value="git4mps" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="3wrDZJThql5" role="3s6cr7">
+        <node concept="3Mxwew" id="3wrDZJThql7" role="3MwsjC">
+          <property role="3MwjfP" value="MPS BaseLanguage stubs for git4idea IDEA plugin. This is necessary for MPS plugins to work with the Git Integration." />
+        </node>
+      </node>
+      <node concept="2iUeEo" id="3wrDZJThql9" role="2iVFfd">
+        <property role="2iUeEt" value="Workday" />
+        <property role="2iUeEu" value="https://www.workday.com/" />
+      </node>
+    </node>
+    <node concept="1E1JtA" id="3wrDZJThqp9" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="git4mps" />
+      <property role="3LESm3" value="b435930b-30fc-42f3-9225-ec36209b7a33" />
+      <property role="2GAjPV" value="true" />
+      <node concept="398BVA" id="3wrDZJThqpa" role="3LF7KH">
+        <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
+        <node concept="2Ry0Ak" id="3wrDZJThqpb" role="iGT6I">
+          <property role="2Ry0Am" value="solutions" />
+          <node concept="2Ry0Ak" id="3wrDZJThqpc" role="2Ry0An">
+            <property role="2Ry0Am" value="git4mps" />
+            <node concept="2Ry0Ak" id="3wrDZJThqpd" role="2Ry0An">
+              <property role="2Ry0Am" value="git4mps.msd" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThqpe" role="3bR37C">
+        <node concept="3bR9La" id="3wrDZJThqpf" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThqpg" role="3bR37C">
+        <node concept="3bR9La" id="3wrDZJThqph" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThqpi" role="3bR37C">
+        <node concept="3bR9La" id="3wrDZJThqpj" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThqpk" role="3bR37C">
+        <node concept="1BurEX" id="3wrDZJThqpl" role="1SiIV1">
+          <node concept="398BVA" id="3wrDZJThqpm" role="1BurEY">
+            <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+            <node concept="2Ry0Ak" id="3wrDZJThqpn" role="iGT6I">
+              <property role="2Ry0Am" value="plugins" />
+              <node concept="2Ry0Ak" id="3wrDZJThqpo" role="2Ry0An">
+                <property role="2Ry0Am" value="git4idea" />
+                <node concept="2Ry0Ak" id="3wrDZJThqpp" role="2Ry0An">
+                  <property role="2Ry0Am" value="lib" />
+                  <node concept="2Ry0Ak" id="3wrDZJThqpq" role="2Ry0An">
+                    <property role="2Ry0Am" value="git4idea-rt.jar" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3yrxFa" id="3wrDZJThqtc" role="2gdwQb">
+            <ref role="3yrxFb" node="5ded7SEwYHh" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThqps" role="3bR37C">
+        <node concept="1BurEX" id="3wrDZJThqpt" role="1SiIV1">
+          <node concept="398BVA" id="3wrDZJThqpu" role="1BurEY">
+            <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+            <node concept="2Ry0Ak" id="3wrDZJThqpv" role="iGT6I">
+              <property role="2Ry0Am" value="plugins" />
+              <node concept="2Ry0Ak" id="3wrDZJThqpw" role="2Ry0An">
+                <property role="2Ry0Am" value="git4idea" />
+                <node concept="2Ry0Ak" id="3wrDZJThqpx" role="2Ry0An">
+                  <property role="2Ry0Am" value="lib" />
+                  <node concept="2Ry0Ak" id="3wrDZJThqpy" role="2Ry0An">
+                    <property role="2Ry0Am" value="git4idea.jar" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3yrxFa" id="3wrDZJThqtN" role="2gdwQb">
+            <ref role="3yrxFb" node="5ded7SEwYN$" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="3wrDZJThs02" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.workday.mps.git4mps" />
+      <property role="3LESm3" value="35a83c38-8969-4574-b716-a7b3acd78eec" />
+      <property role="2GAjPV" value="false" />
+      <node concept="398BVA" id="3wrDZJThs49" role="3LF7KH">
+        <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
+        <node concept="2Ry0Ak" id="3wrDZJThs5n" role="iGT6I">
+          <property role="2Ry0Am" value="solutions" />
+          <node concept="2Ry0Ak" id="3wrDZJThs7G" role="2Ry0An">
+            <property role="2Ry0Am" value="com.workday.mps.git4mps" />
+            <node concept="2Ry0Ak" id="7mrE8nX2huj" role="2Ry0An">
+              <property role="2Ry0Am" value="com.workday.mps.git4mps.msd" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThsa3" role="3bR37C">
+        <node concept="3bR9La" id="3wrDZJThsa4" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3wrDZJThsa5" role="3bR37C">
+        <node concept="3bR9La" id="3wrDZJThsa6" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1l3spW" id="4GMBmWUHnV9">
+    <property role="2DA0ip" value="../../dist" />
+    <property role="TrG5h" value="IDEA_gitplugin_stubs" />
+    <property role="turDy" value="ideaGitPlugin.xml" />
+    <node concept="398rNT" id="7SqVNqmbZQb" role="1l3spd">
+      <property role="TrG5h" value="project.home" />
+      <node concept="55IIr" id="7SqVNqmbZQc" role="398pKh">
+        <node concept="2Ry0Ak" id="7SqVNqmbZQd" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7SqVNqmbZOo" role="1l3spd">
+      <property role="TrG5h" value="artifacts.root" />
+      <node concept="398BVA" id="7SqVNqmbZOp" role="398pKh">
+        <ref role="398BVh" node="7SqVNqmbZQb" resolve="project.home" />
+        <node concept="2Ry0Ak" id="7SqVNqmbZOq" role="iGT6I">
+          <property role="2Ry0Am" value="artifacts" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="7SqVNqmbZOr" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+      <node concept="398BVA" id="7SqVNqmbZOs" role="398pKh">
+        <ref role="398BVh" node="7SqVNqmbZOo" resolve="artifacts.root" />
+        <node concept="2Ry0Ak" id="7SqVNqmbZOt" role="iGT6I">
+          <property role="2Ry0Am" value="MPS" />
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="645f3xJ3KbN" role="1l3spd">
+      <property role="TrG5h" value="git4idea.home" />
+      <node concept="398BVA" id="4GMBmWUH$WL" role="398pKh">
+        <ref role="398BVh" node="7SqVNqmbZOr" resolve="mps.home" />
+        <node concept="2Ry0Ak" id="4GMBmWUH$WQ" role="iGT6I">
+          <property role="2Ry0Am" value="plugins" />
+          <node concept="2Ry0Ak" id="4GMBmWUH$WV" role="2Ry0An">
+            <property role="2Ry0Am" value="git4idea" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="55IIr" id="4GMBmWUHnVa" role="auvoZ" />
+    <node concept="1l3spV" id="4GMBmWUHnVb" role="1l3spN">
+      <node concept="m$_wl" id="4GMBmWUH$Xn" role="39821P">
+        <ref role="m_rDy" node="4GMBmWUHpN2" resolve="Git4Idea" />
+        <node concept="398223" id="5ded7SEwNA6" role="39821P">
+          <node concept="3_J27D" id="5ded7SEwNA8" role="Nbhlr">
+            <node concept="3Mxwew" id="5ded7SEwNSZ" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
+            </node>
+          </node>
+          <node concept="28jJK3" id="5ded7SEwYHh" role="39821P">
+            <node concept="398BVA" id="5ded7SEwYHL" role="28jJRO">
+              <ref role="398BVh" node="645f3xJ3KbN" resolve="git4idea.home" />
+              <node concept="2Ry0Ak" id="5ded7SEwYHR" role="iGT6I">
+                <property role="2Ry0Am" value="lib" />
+                <node concept="2Ry0Ak" id="5ded7SEwYHW" role="2Ry0An">
+                  <property role="2Ry0Am" value="git4idea-rt.jar" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="28jJK3" id="5ded7SEwYN$" role="39821P">
+            <node concept="398BVA" id="5ded7SEwYN_" role="28jJRO">
+              <ref role="398BVh" node="645f3xJ3KbN" resolve="git4idea.home" />
+              <node concept="2Ry0Ak" id="5ded7SEwYNA" role="iGT6I">
+                <property role="2Ry0Am" value="lib" />
+                <node concept="2Ry0Ak" id="5ded7SEwYQC" role="2Ry0An">
+                  <property role="2Ry0Am" value="git4idea.jar" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="10PD9b" id="4GMBmWUHpMO" role="10PD9s" />
+    <node concept="3b7kt6" id="4GMBmWUHpMT" role="10PD9s" />
+    <node concept="m$_wf" id="4GMBmWUHpN2" role="3989C9">
+      <property role="m$_wk" value="Git4Idea" />
+      <node concept="3_J27D" id="4GMBmWUHpN3" role="m_cZH">
+        <node concept="3Mxwew" id="4GMBmWUHq6$" role="3MwsjC">
+          <property role="3MwjfP" value="git4idea" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="4GMBmWUHpN4" role="m$_w8">
+        <node concept="3Mxwew" id="4GMBmWUHq6K" role="3MwsjC">
+          <property role="3MwjfP" value="&lt;empty&gt;" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="4GMBmWUHpN5" role="m$_yQ">
+        <node concept="3Mxwew" id="4GMBmWUHq6f" role="3MwsjC">
+          <property role="3MwjfP" value="Git Integration" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/solutions/com.workday.mps.review.build.meta/com.workday.mps.review.build.meta.msd
+++ b/solutions/com.workday.mps.review.build.meta/com.workday.mps.review.build.meta.msd
@@ -9,16 +9,16 @@
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
     <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
+    <dependency reexport="false">35a83c38-8969-4574-b716-a7b3acd78eec(com.workday.mps.git4mps)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
     <language slang="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" version="5" />
-    <language slang="l:479c7a8c-02f9-43b5-9139-d910cb22f298:jetbrains.mps.core.xml" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
-    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
+    <module reference="35a83c38-8969-4574-b716-a7b3acd78eec(com.workday.mps.git4mps)" version="0" />
     <module reference="647b24df-0989-4dda-8a80-df171228d489(com.workday.mps.review.build.meta)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
   </dependencyVersions>

--- a/solutions/com.workday.mps.review.build.meta/models/com.workday.mps.review.build.meta.mps
+++ b/solutions/com.workday.mps.review.build.meta/models/com.workday.mps.review.build.meta.mps
@@ -4,11 +4,9 @@
   <languages>
     <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
-    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="hh2c" ref="r:5c70a88b-9c77-4970-b930-a9ff601a03a0(jetbrains.mps.ide.idea.plugin.build)" />
     <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
   </imports>
   <registry>
@@ -80,6 +78,36 @@
     <property role="2DA0ip" value="../../buildScripts" />
     <property role="TrG5h" value="reviewPluginBuildScripts" />
     <property role="turDy" value="reviewPluginBuildScripts.xml" />
+    <node concept="1E1JtA" id="3PM$dUaz5gE" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="com.workday.mps.git4mps" />
+      <property role="3LESm3" value="35a83c38-8969-4574-b716-a7b3acd78eec" />
+      <property role="2GAjPV" value="false" />
+      <node concept="398BVA" id="3PM$dUaz5hF" role="3LF7KH">
+        <ref role="398BVh" node="3c3vDUluIXm" resolve="project.home" />
+        <node concept="2Ry0Ak" id="3PM$dUaz5hZ" role="iGT6I">
+          <property role="2Ry0Am" value="solutions" />
+          <node concept="2Ry0Ak" id="3PM$dUaz5ii" role="2Ry0An">
+            <property role="2Ry0Am" value="com.workday.mps.git4mps" />
+            <node concept="2Ry0Ak" id="7mrE8nX2hsP" role="2Ry0An">
+              <property role="2Ry0Am" value="com.workday.mps.git4mps.msd" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3PM$dUaz5i_" role="3bR37C">
+        <node concept="3bR9La" id="3PM$dUaz5iA" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3PM$dUaz5iB" role="3bR37C">
+        <node concept="3bR9La" id="3PM$dUaz5iC" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+    </node>
     <node concept="2sgV4H" id="4hhvq7oWSQZ" role="1l3spa">
       <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
       <node concept="398BVA" id="4hhvq7oWSR0" role="2JcizS">
@@ -129,6 +157,9 @@
     </node>
     <node concept="55IIr" id="3c3vDUluHHF" role="auvoZ" />
     <node concept="1l3spV" id="3c3vDUluHHG" role="1l3spN">
+      <node concept="L2wRC" id="3PM$dUaz5kc" role="39821P">
+        <ref role="L2wRA" node="3PM$dUaz5gE" resolve="com.workday.mps.git4mps" />
+      </node>
       <node concept="L2wRC" id="24ZpFMHU7Vd" role="39821P">
         <ref role="L2wRA" node="24ZpFMHU7Uv" resolve="com.workday.mps.review.build" />
       </node>
@@ -162,6 +193,12 @@
         <node concept="3bR9La" id="24ZpFMHUlOD" role="1SiIV1">
           <property role="3bR36h" value="false" />
           <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3PM$dUazcEx" role="3bR37C">
+        <node concept="3bR9La" id="3PM$dUazcEy" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" node="3PM$dUaz5gE" resolve="com.workday.mps.git4mps" />
         </node>
       </node>
     </node>

--- a/solutions/com.workday.mps.review.build/models/com.workday.mps.review.build.mps
+++ b/solutions/com.workday.mps.review.build/models/com.workday.mps.review.build.mps
@@ -4,19 +4,15 @@
   <languages>
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
     <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="5" />
-    <use id="479c7a8c-02f9-43b5-9139-d910cb22f298" name="jetbrains.mps.core.xml" version="0" />
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="hh2c" ref="r:5c70a88b-9c77-4970-b930-a9ff601a03a0(jetbrains.mps.ide.idea.plugin.build)" />
     <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
+    <import index="mp9h" ref="r:ce9396f7-a2dc-46eb-9df9-af482f8fe831(com.workday.mps.git4mps.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
       <concept id="5481553824944787378" name="jetbrains.mps.build.structure.BuildSourceProjectRelativePath" flags="ng" index="55IIr" />
-      <concept id="9126048691955220717" name="jetbrains.mps.build.structure.BuildLayout_File" flags="ng" index="28jJK3">
-        <child id="9126048691955220762" name="path" index="28jJRO" />
-      </concept>
       <concept id="7321017245476976379" name="jetbrains.mps.build.structure.BuildRelativePath" flags="ng" index="iG8Mu">
         <child id="7321017245477039051" name="compositePart" index="iGT6I" />
       </concept>
@@ -38,7 +34,6 @@
         <child id="8618885170173601778" name="tail" index="2Ry0An" />
       </concept>
       <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
-      <concept id="7389400916848050071" name="jetbrains.mps.build.structure.BuildLayout_Zip" flags="ng" index="3981dG" />
       <concept id="7389400916848050060" name="jetbrains.mps.build.structure.BuildLayout_NamedContainer" flags="ng" index="3981dR">
         <child id="4380385936562148502" name="containerName" index="Nbhlr" />
       </concept>
@@ -66,9 +61,6 @@
       </concept>
       <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
-      </concept>
-      <concept id="5610619299014309452" name="jetbrains.mps.build.structure.BuildSource_JavaExternalJarRef" flags="ng" index="3yrxFa">
-        <reference id="5610619299014309453" name="jar" index="3yrxFb" />
       </concept>
       <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
       <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
@@ -107,15 +99,10 @@
         <reference id="6592112598314801433" name="plugin" index="m_rDy" />
       </concept>
       <concept id="6592112598314499036" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginModule" flags="ng" index="m$_yB">
-        <property id="4034578608468849375" name="customPackaging" index="1ZOk41" />
         <reference id="6592112598314499037" name="target" index="m$_yA" />
       </concept>
       <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
         <reference id="6592112598314499066" name="target" index="m$_y1" />
-      </concept>
-      <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
-        <reference id="1265949165890536425" name="module" index="L2wRA" />
-        <child id="4356762679305730677" name="jarLocations" index="3yL2VB" />
       </concept>
       <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
       <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
@@ -130,12 +117,7 @@
       <concept id="763829979718664966" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleResources" flags="ng" index="3rtmxn">
         <child id="763829979718664967" name="files" index="3rtmxm" />
       </concept>
-      <concept id="4356762679305675652" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleXml_CustomJarLocation" flags="ng" index="3yLZsm">
-        <property id="4356762679305675654" name="packagedLocation" index="3yLZsk" />
-        <child id="4356762679305675653" name="path" index="3yLZsn" />
-      </concept>
       <concept id="4278635856200826393" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyJar" flags="ng" index="1BurEX">
-        <child id="2798275735916344703" name="customLocation" index="2gdwQb" />
         <child id="4278635856200826394" name="path" index="1BurEY" />
       </concept>
       <concept id="4278635856200794926" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyExtendLanguage" flags="ng" index="1Busua">
@@ -170,19 +152,22 @@
         <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
       </node>
     </node>
-    <node concept="2sgV4H" id="7SqVNqmc0Tt" role="1l3spa">
-      <ref role="1l3spb" node="4GMBmWUHnV9" resolve="IDEA_gitplugin_subs" />
-      <node concept="398BVA" id="7SqVNqmc0Va" role="2JcizS">
-        <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-        <node concept="2Ry0Ak" id="7SqVNqmc0W1" role="iGT6I">
-          <property role="2Ry0Am" value="plugins" />
-        </node>
-      </node>
-    </node>
     <node concept="2sgV4H" id="24ZpFMHU7SY" role="1l3spa">
       <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
       <node concept="398BVA" id="24ZpFMHU7TK" role="2JcizS">
         <ref role="398BVh" node="24ZpFMHU2s7" resolve="com.mbeddr.platform.artifacts" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="3wrDZJThzXr" role="1l3spa">
+      <ref role="1l3spb" to="mp9h:3wrDZJThqks" resolve="git4mpsPlugin" />
+    </node>
+    <node concept="2sgV4H" id="3wrDZJThqlq" role="1l3spa">
+      <ref role="1l3spb" to="mp9h:4GMBmWUHnV9" resolve="IDEA_gitplugin_stubs" />
+      <node concept="398BVA" id="3wrDZJThqlr" role="2JcizS">
+        <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
+        <node concept="2Ry0Ak" id="3wrDZJThqls" role="iGT6I">
+          <property role="2Ry0Am" value="plugins" />
+        </node>
       </node>
     </node>
     <node concept="398rNT" id="24ZpFMHU9ep" role="1l3spd">
@@ -222,89 +207,26 @@
     </node>
     <node concept="55IIr" id="3c3vDUluHHF" role="auvoZ" />
     <node concept="1l3spV" id="3c3vDUluHHG" role="1l3spN">
-      <node concept="3981dG" id="145rAk1QFxH" role="39821P">
-        <node concept="3_J27D" id="145rAk1QFxI" role="Nbhlr">
-          <node concept="3Mxwew" id="145rAk1QFxN" role="3MwsjC">
-            <property role="3MwjfP" value="com.workday.mps.review.zip" />
-          </node>
-        </node>
-        <node concept="m$_wl" id="145rAk1QFxP" role="39821P">
-          <ref role="m_rDy" node="7ZoWiKcez96" resolve="com.workday.mps.review" />
-          <node concept="398223" id="5gg_jpIHI0o" role="39821P">
-            <node concept="2HvfSZ" id="3c3vDUlvyB3" role="39821P">
-              <node concept="398BVA" id="3c3vDUlvyCX" role="2HvfZ0">
-                <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
-                <node concept="2Ry0Ak" id="3c3vDUlvyEb" role="iGT6I">
-                  <property role="2Ry0Am" value="solutions" />
-                  <node concept="2Ry0Ak" id="3c3vDUlvyEi" role="2Ry0An">
-                    <property role="2Ry0Am" value="com.workday.mps.review" />
-                    <node concept="2Ry0Ak" id="NvAZPok24z" role="2Ry0An">
-                      <property role="2Ry0Am" value="lib" />
-                    </node>
+      <node concept="m$_wl" id="145rAk1QFxP" role="39821P">
+        <ref role="m_rDy" node="7ZoWiKcez96" resolve="com.workday.mps.review" />
+        <node concept="398223" id="5gg_jpIHI0o" role="39821P">
+          <node concept="2HvfSZ" id="3c3vDUlvyB3" role="39821P">
+            <node concept="398BVA" id="3c3vDUlvyCX" role="2HvfZ0">
+              <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
+              <node concept="2Ry0Ak" id="3c3vDUlvyEb" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3c3vDUlvyEi" role="2Ry0An">
+                  <property role="2Ry0Am" value="com.workday.mps.review" />
+                  <node concept="2Ry0Ak" id="NvAZPok24z" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3_J27D" id="5gg_jpIHI0p" role="Nbhlr">
-              <node concept="3Mxwew" id="5gg_jpIHI0A" role="3MwsjC">
-                <property role="3MwjfP" value="lib" />
-              </node>
-            </node>
           </node>
-        </node>
-      </node>
-      <node concept="3981dG" id="7SqVNqmc0B5" role="39821P">
-        <node concept="3_J27D" id="7SqVNqmc0B6" role="Nbhlr">
-          <node concept="3Mxwew" id="7SqVNqmc0B7" role="3MwsjC">
-            <property role="3MwjfP" value="git4mps.zip" />
-          </node>
-        </node>
-        <node concept="m$_wl" id="7SqVNqmc0B8" role="39821P">
-          <ref role="m_rDy" node="24ZpFMHUaDd" resolve="git4mps" />
-          <node concept="398223" id="7SqVNqmc0HO" role="39821P">
-            <node concept="3_J27D" id="7SqVNqmc0HP" role="Nbhlr">
-              <node concept="3Mxwew" id="7SqVNqmc0HW" role="3MwsjC">
-                <property role="3MwjfP" value="languages" />
-              </node>
-            </node>
-            <node concept="L2wRC" id="7SqVNqmc0Jt" role="39821P">
-              <ref role="L2wRA" node="7SqVNqmbZUB" resolve="git4mps" />
-              <node concept="3yLZsm" id="386y71hfagv" role="3yL2VB">
-                <property role="3yLZsk" value="/plugins/git4idea/lib/git4idea-rt.jar" />
-                <node concept="398BVA" id="386y71hfaj_" role="3yLZsn">
-                  <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-                  <node concept="2Ry0Ak" id="386y71hfajC" role="iGT6I">
-                    <property role="2Ry0Am" value="plugins" />
-                    <node concept="2Ry0Ak" id="1VZZCFrW2ji" role="2Ry0An">
-                      <property role="2Ry0Am" value="git4idea" />
-                      <node concept="2Ry0Ak" id="1VZZCFrW2jj" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="1VZZCFrW2jk" role="2Ry0An">
-                          <property role="2Ry0Am" value="git4idea-rt.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3yLZsm" id="386y71hfagD" role="3yL2VB">
-                <property role="3yLZsk" value="/plugins/git4idea/lib/git4idea.jar" />
-                <node concept="398BVA" id="386y71hfak3" role="3yLZsn">
-                  <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-                  <node concept="2Ry0Ak" id="386y71hfak6" role="iGT6I">
-                    <property role="2Ry0Am" value="plugins" />
-                    <node concept="2Ry0Ak" id="1VZZCFrW2ok" role="2Ry0An">
-                      <property role="2Ry0Am" value="git4idea" />
-                      <node concept="2Ry0Ak" id="1VZZCFrW2ol" role="2Ry0An">
-                        <property role="2Ry0Am" value="lib" />
-                        <node concept="2Ry0Ak" id="1VZZCFrW2om" role="2Ry0An">
-                          <property role="2Ry0Am" value="git4idea.jar" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+          <node concept="3_J27D" id="5gg_jpIHI0p" role="Nbhlr">
+            <node concept="3Mxwew" id="5gg_jpIHI0A" role="3MwsjC">
+              <property role="3MwjfP" value="lib" />
             </node>
           </node>
         </node>
@@ -312,46 +234,6 @@
     </node>
     <node concept="10PD9b" id="3c3vDUluHHH" role="10PD9s" />
     <node concept="3b7kt6" id="3c3vDUluIVL" role="10PD9s" />
-    <node concept="m$_wf" id="24ZpFMHUaDd" role="3989C9">
-      <property role="m$_wk" value="git4mps" />
-      <node concept="3_J27D" id="24ZpFMHUaDh" role="m$_yQ">
-        <node concept="3Mxwew" id="24ZpFMHUaDi" role="3MwsjC">
-          <property role="3MwjfP" value="Git Integration - MPS Stubs" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="24ZpFMHUaDj" role="m_cZH">
-        <node concept="3Mxwew" id="24ZpFMHUaDk" role="3MwsjC">
-          <property role="3MwjfP" value="git4mps" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="24ZpFMHUaDl" role="m$_w8">
-        <node concept="3Mxwew" id="24ZpFMHUaDm" role="3MwsjC">
-          <property role="3MwjfP" value="1.0.0" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="24ZpFMHUaDn" role="3s6cr7">
-        <node concept="3Mxwew" id="24ZpFMHUaDo" role="3MwsjC">
-          <property role="3MwjfP" value="MPS BaseLanguage stubs for git4idea IDEA plugin. This is necessary for MPS plugins to work with the Git Integration." />
-        </node>
-      </node>
-      <node concept="m$_yC" id="24ZpFMHUaDq" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:4k71ibbKLe8" resolve="jetbrains.mps.core" />
-      </node>
-      <node concept="m$_yC" id="24ZpFMHUaDr" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
-      </node>
-      <node concept="m$_yC" id="7SqVNqmc1me" role="m$_yJ">
-        <ref role="m$_y1" to="ffeo:I6XuqGYf8K" resolve="Git4Idea" />
-      </node>
-      <node concept="m$_yB" id="7SqVNqmc0Ql" role="m$_yh">
-        <property role="1ZOk41" value="true" />
-        <ref role="m$_yA" node="7SqVNqmbZUB" resolve="git4mps" />
-      </node>
-      <node concept="2iUeEo" id="lCZbGfRXeR" role="2iVFfd">
-        <property role="2iUeEt" value="Workday" />
-        <property role="2iUeEu" value="https://www.workday.com/" />
-      </node>
-    </node>
     <node concept="m$_wf" id="7ZoWiKcez96" role="3989C9">
       <property role="m$_wk" value="com.workday.mps.review" />
       <node concept="3_J27D" id="7ZoWiKcez98" role="m$_yQ">
@@ -384,8 +266,8 @@
       <node concept="m$_yC" id="3c3vDUlxVVQ" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
       </node>
-      <node concept="m$_yC" id="24ZpFMHUaIA" role="m$_yJ">
-        <ref role="m$_y1" node="24ZpFMHUaDd" resolve="git4mps" />
+      <node concept="m$_yC" id="3wrDZJThzY1" role="m$_yJ">
+        <ref role="m$_y1" to="mp9h:3wrDZJThqkR" resolve="git4mps" />
       </node>
       <node concept="m$_yB" id="7SqVNqmc1gN" role="m$_yh">
         <ref role="m$_yA" node="3c3vDUlvEDO" resolve="com.workday.mps.flux" />
@@ -398,86 +280,6 @@
       </node>
       <node concept="m$_yB" id="7SqVNqmc1ks" role="m$_yh">
         <ref role="m$_yA" node="NvAZPok1Na" resolve="com.workday.mps.review.lang" />
-      </node>
-    </node>
-    <node concept="1E1JtA" id="7SqVNqmbZUB" role="3989C9">
-      <property role="BnDLt" value="true" />
-      <property role="TrG5h" value="git4mps" />
-      <property role="3LESm3" value="b435930b-30fc-42f3-9225-ec36209b7a33" />
-      <property role="2GAjPV" value="true" />
-      <node concept="398BVA" id="7SqVNqmbZUC" role="3LF7KH">
-        <ref role="398BVh" node="24ZpFMHU9ep" resolve="project.home" />
-        <node concept="2Ry0Ak" id="7SqVNqmbZUD" role="iGT6I">
-          <property role="2Ry0Am" value="solutions" />
-          <node concept="2Ry0Ak" id="7SqVNqmbZUE" role="2Ry0An">
-            <property role="2Ry0Am" value="git4mps" />
-            <node concept="2Ry0Ak" id="2_WcI2qoxAf" role="2Ry0An">
-              <property role="2Ry0Am" value="git4mps.msd" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1SiIV0" id="7SqVNqmbZUG" role="3bR37C">
-        <node concept="3bR9La" id="7SqVNqmbZUH" role="1SiIV1">
-          <property role="3bR36h" value="false" />
-          <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
-        </node>
-      </node>
-      <node concept="1SiIV0" id="7SqVNqmbZUI" role="3bR37C">
-        <node concept="3bR9La" id="7SqVNqmbZUJ" role="1SiIV1">
-          <property role="3bR36h" value="false" />
-          <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
-        </node>
-      </node>
-      <node concept="1SiIV0" id="7SqVNqmbZUK" role="3bR37C">
-        <node concept="3bR9La" id="7SqVNqmbZUL" role="1SiIV1">
-          <property role="3bR36h" value="false" />
-          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-        </node>
-      </node>
-      <node concept="1SiIV0" id="1VZZCFrVOm3" role="3bR37C">
-        <node concept="1BurEX" id="1VZZCFrVOm4" role="1SiIV1">
-          <node concept="398BVA" id="1VZZCFrVOlU" role="1BurEY">
-            <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-            <node concept="2Ry0Ak" id="1VZZCFrVOlV" role="iGT6I">
-              <property role="2Ry0Am" value="plugins" />
-              <node concept="2Ry0Ak" id="1VZZCFrW21g" role="2Ry0An">
-                <property role="2Ry0Am" value="git4idea" />
-                <node concept="2Ry0Ak" id="1VZZCFrW21h" role="2Ry0An">
-                  <property role="2Ry0Am" value="lib" />
-                  <node concept="2Ry0Ak" id="1VZZCFrW21i" role="2Ry0An">
-                    <property role="2Ry0Am" value="git4idea-rt.jar" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3yrxFa" id="1WYef1dBkhn" role="2gdwQb">
-            <ref role="3yrxFb" node="5ded7SEwYHh" />
-          </node>
-        </node>
-      </node>
-      <node concept="1SiIV0" id="1VZZCFrVOme" role="3bR37C">
-        <node concept="1BurEX" id="1VZZCFrVOmf" role="1SiIV1">
-          <node concept="398BVA" id="1VZZCFrVOm5" role="1BurEY">
-            <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-            <node concept="2Ry0Ak" id="1VZZCFrVOm6" role="iGT6I">
-              <property role="2Ry0Am" value="plugins" />
-              <node concept="2Ry0Ak" id="1VZZCFrW25J" role="2Ry0An">
-                <property role="2Ry0Am" value="git4idea" />
-                <node concept="2Ry0Ak" id="1VZZCFrW25K" role="2Ry0An">
-                  <property role="2Ry0Am" value="lib" />
-                  <node concept="2Ry0Ak" id="1VZZCFrW25L" role="2Ry0An">
-                    <property role="2Ry0Am" value="git4idea.jar" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3yrxFa" id="1WYef1dBkhX" role="2gdwQb">
-            <ref role="3yrxFb" node="5ded7SEwYN$" />
-          </node>
-        </node>
       </node>
     </node>
     <node concept="1E1JtA" id="3c3vDUlvEDO" role="3989C9">
@@ -707,9 +509,9 @@
         </node>
       </node>
       <node concept="1SiIV0" id="24ZpFMHUaBW" role="3bR37C">
-        <node concept="3bR9La" id="24ZpFMHUaBX" role="1SiIV1">
+        <node concept="3bR9La" id="3wrDZJThzY_" role="1SiIV1">
           <property role="3bR36h" value="true" />
-          <ref role="3bR37D" node="7SqVNqmbZUB" resolve="git4mps" />
+          <ref role="3bR37D" to="mp9h:3wrDZJThqp9" resolve="git4mps" />
         </node>
       </node>
       <node concept="3rtmxn" id="7Uvm6D4BW1I" role="3bR31x">
@@ -801,104 +603,6 @@
               </node>
             </node>
           </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1l3spW" id="4GMBmWUHnV9">
-    <property role="2DA0ip" value="../../dist" />
-    <property role="TrG5h" value="IDEA_gitplugin_subs" />
-    <property role="turDy" value="ideaGitPlugin.xml" />
-    <node concept="398rNT" id="7SqVNqmbZQb" role="1l3spd">
-      <property role="TrG5h" value="project.home" />
-      <node concept="55IIr" id="7SqVNqmbZQc" role="398pKh">
-        <node concept="2Ry0Ak" id="7SqVNqmbZQd" role="iGT6I">
-          <property role="2Ry0Am" value=".." />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7SqVNqmbZOo" role="1l3spd">
-      <property role="TrG5h" value="artifacts.root" />
-      <node concept="398BVA" id="7SqVNqmbZOp" role="398pKh">
-        <ref role="398BVh" node="7SqVNqmbZQb" resolve="project.home" />
-        <node concept="2Ry0Ak" id="7SqVNqmbZOq" role="iGT6I">
-          <property role="2Ry0Am" value="artifacts" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="7SqVNqmbZOr" role="1l3spd">
-      <property role="TrG5h" value="mps.home" />
-      <node concept="398BVA" id="7SqVNqmbZOs" role="398pKh">
-        <ref role="398BVh" node="7SqVNqmbZOo" resolve="artifacts.root" />
-        <node concept="2Ry0Ak" id="7SqVNqmbZOt" role="iGT6I">
-          <property role="2Ry0Am" value="MPS" />
-        </node>
-      </node>
-    </node>
-    <node concept="398rNT" id="645f3xJ3KbN" role="1l3spd">
-      <property role="TrG5h" value="git4idea.home" />
-      <node concept="398BVA" id="4GMBmWUH$WL" role="398pKh">
-        <ref role="398BVh" node="7SqVNqmbZOr" resolve="mps.home" />
-        <node concept="2Ry0Ak" id="4GMBmWUH$WQ" role="iGT6I">
-          <property role="2Ry0Am" value="plugins" />
-          <node concept="2Ry0Ak" id="4GMBmWUH$WV" role="2Ry0An">
-            <property role="2Ry0Am" value="git4idea" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="55IIr" id="4GMBmWUHnVa" role="auvoZ" />
-    <node concept="1l3spV" id="4GMBmWUHnVb" role="1l3spN">
-      <node concept="m$_wl" id="4GMBmWUH$Xn" role="39821P">
-        <ref role="m_rDy" node="4GMBmWUHpN2" resolve="Git4Idea" />
-        <node concept="398223" id="5ded7SEwNA6" role="39821P">
-          <node concept="3_J27D" id="5ded7SEwNA8" role="Nbhlr">
-            <node concept="3Mxwew" id="5ded7SEwNSZ" role="3MwsjC">
-              <property role="3MwjfP" value="lib" />
-            </node>
-          </node>
-          <node concept="28jJK3" id="5ded7SEwYHh" role="39821P">
-            <node concept="398BVA" id="5ded7SEwYHL" role="28jJRO">
-              <ref role="398BVh" node="645f3xJ3KbN" resolve="git4idea.home" />
-              <node concept="2Ry0Ak" id="5ded7SEwYHR" role="iGT6I">
-                <property role="2Ry0Am" value="lib" />
-                <node concept="2Ry0Ak" id="5ded7SEwYHW" role="2Ry0An">
-                  <property role="2Ry0Am" value="git4idea-rt.jar" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="28jJK3" id="5ded7SEwYN$" role="39821P">
-            <node concept="398BVA" id="5ded7SEwYN_" role="28jJRO">
-              <ref role="398BVh" node="645f3xJ3KbN" resolve="git4idea.home" />
-              <node concept="2Ry0Ak" id="5ded7SEwYNA" role="iGT6I">
-                <property role="2Ry0Am" value="lib" />
-                <node concept="2Ry0Ak" id="5ded7SEwYQC" role="2Ry0An">
-                  <property role="2Ry0Am" value="git4idea.jar" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="10PD9b" id="4GMBmWUHpMO" role="10PD9s" />
-    <node concept="3b7kt6" id="4GMBmWUHpMT" role="10PD9s" />
-    <node concept="m$_wf" id="4GMBmWUHpN2" role="3989C9">
-      <property role="m$_wk" value="Git4Idea" />
-      <node concept="3_J27D" id="4GMBmWUHpN3" role="m_cZH">
-        <node concept="3Mxwew" id="4GMBmWUHq6$" role="3MwsjC">
-          <property role="3MwjfP" value="git4idea" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="4GMBmWUHpN4" role="m$_w8">
-        <node concept="3Mxwew" id="4GMBmWUHq6K" role="3MwsjC">
-          <property role="3MwjfP" value="&lt;empty&gt;" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="4GMBmWUHpN5" role="m$_yQ">
-        <node concept="3Mxwew" id="4GMBmWUHq6f" role="3MwsjC">
-          <property role="3MwjfP" value="Git Integration" />
         </node>
       </node>
     </node>

--- a/solutions/com.workday.mps.review.build/models/com.workday.mps.review.build.mps
+++ b/solutions/com.workday.mps.review.build/models/com.workday.mps.review.build.mps
@@ -161,15 +161,6 @@
     <node concept="2sgV4H" id="3wrDZJThzXr" role="1l3spa">
       <ref role="1l3spb" to="mp9h:3wrDZJThqks" resolve="git4mpsPlugin" />
     </node>
-    <node concept="2sgV4H" id="3wrDZJThqlq" role="1l3spa">
-      <ref role="1l3spb" to="mp9h:4GMBmWUHnV9" resolve="IDEA_gitplugin_stubs" />
-      <node concept="398BVA" id="3wrDZJThqlr" role="2JcizS">
-        <ref role="398BVh" node="24ZpFMHU9es" resolve="mps_home" />
-        <node concept="2Ry0Ak" id="3wrDZJThqls" role="iGT6I">
-          <property role="2Ry0Am" value="plugins" />
-        </node>
-      </node>
-    </node>
     <node concept="398rNT" id="24ZpFMHU9ep" role="1l3spd">
       <property role="TrG5h" value="project.home" />
       <node concept="55IIr" id="24ZpFMHU9eq" role="398pKh">
@@ -267,7 +258,7 @@
         <ref role="m$_y1" to="ffeo:RJsmGEieyQ" resolve="jetbrains.mps.vcs" />
       </node>
       <node concept="m$_yC" id="3wrDZJThzY1" role="m$_yJ">
-        <ref role="m$_y1" to="mp9h:3wrDZJThqkR" resolve="git4mps" />
+        <ref role="m$_y1" to="mp9h:3wrDZJThqkR" resolve="com.workday.mps.git4mps" />
       </node>
       <node concept="m$_yB" id="7SqVNqmc1gN" role="m$_yh">
         <ref role="m$_yA" node="3c3vDUlvEDO" resolve="com.workday.mps.flux" />


### PR DESCRIPTION
This change is to separate out the git4mps plugin from the main code reviewer plugin.
I've also change the output from zip file to the unzipped form and let gradle build script take care of the zipping step.

One thing I noticed is that **_.ds_store_** keep getting zipped even though gradle zip task should by default ignore them (or maybe I am wrong), I need some hints to do this part correctly. Currently MPS complains when trying to install the plugins because of the **_.ds_store_** files.

This is still work in progress, but I'd like to get some early feedback is possible.